### PR TITLE
Update v2025.02.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: b8fa0329f2797283c7895e7dd0fe424a977f2d255e9c95cc9b20261ecc790810
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win]
   script: {{ PYTHON }} -m pip install . -vv
 
@@ -23,13 +23,14 @@ requirements:
     - cross-python_{{ target_platform }}  # [build_platform != target_platform]
     - cython                              # [build_platform != target_platform]
     - numpy                               # [build_platform != target_platform]
+    - tempo2                              # [build_platform != target_platform]
   host:
     - cython
     - numpy
     - pip
     - python
     - setuptools
-    - tempo2 >=2020.11.1
+    - tempo2 >=2024.04.1
   run:
     - astropy-base >=4.1
     - ephem >=3.7.7.1
@@ -38,7 +39,7 @@ requirements:
     - python
     - pyerfa
     - scipy
-    - tempo2 >=2020.11.1
+    - tempo2 >=2024.04.1
 
 test:
   imports:


### PR DESCRIPTION
Include tempo2 in build to see if it fixes the error from https://github.com/vallis/libstempo/issues/49 also seen in the builds in https://github.com/conda-forge/cwinpy-feedstock/pull/64.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
